### PR TITLE
VSRE-414: Update lib version

### DIFF
--- a/lib/yeti_thrift/version.rb
+++ b/lib/yeti_thrift/version.rb
@@ -1,3 +1,3 @@
 module YetiThrift
-  VERSION = "3.0.1"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
Update lib to version 4.0.0 to make correct current version visible when using this gem as a dependency

@vendasta/sre 