### PR TITLE
Fix activesupport requires to support AS v7.1.0 or newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # yeti_thrift Changelog
 
+## v3.0.2, December 4, 2022
+- Update to work with newer (7.1.0+) ActiveSupport versions
+
 ## v3.0.1, October 6, 2016
 - Explicitly require `Object#try` from `ActiveSupport`.
 - New shared examples for testing required fields and unions.

--- a/lib/gem_ext/thrift/struct/struct_version.rb
+++ b/lib/gem_ext/thrift/struct/struct_version.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/string/inflections'
 require 'yeti_thrift/exceptions'
 

--- a/lib/gem_ext/thrift/struct_union/timestamp.rb
+++ b/lib/gem_ext/thrift/struct_union/timestamp.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/array/extract_options'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/time/zones'

--- a/lib/yeti_thrift.rb
+++ b/lib/yeti_thrift.rb
@@ -9,6 +9,7 @@ require "yeti_thrift/serializer"
 require "yeti_thrift/base64_deserializer"
 require "yeti_thrift/base64_serializer"
 require 'yeti_thrift/rake/thrift_gen_task'
+require 'active_support'
 require 'active_support/core_ext/object'
 
 # Check field types when assigning to structs

--- a/lib/yeti_thrift/version.rb
+++ b/lib/yeti_thrift/version.rb
@@ -1,3 +1,3 @@
 module YetiThrift
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
 end

--- a/spec/lib/gem_ext/thrift/struct_union/timestamp_spec.rb
+++ b/spec/lib/gem_ext/thrift/struct_union/timestamp_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'active_support'
 
 describe Thrift::Struct_Union, 'timestamp' do
 


### PR DESCRIPTION
Wherever we require any core extensions from ActiveSupport, we'll need to also add `require 'active_support'` to get things working; see https://github.com/rails/rails/issues/49495 for an example.

To allow for continued compatibility with ActiveSupport > 7.0.8, we need to add these lines.